### PR TITLE
undo changes to mod_exists_via_show + additional/enhanced tests

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -543,21 +543,9 @@ class ModulesTool(object):
 
             :param mod_name: module name
             """
+            mod_exists_regex = mod_exists_regex_template % re.escape(mod_name)
             txt = self.show(mod_name)
-            res = False
-            names_to_check = [mod_name]
-            # The module might be an alias where the target can be arbitrary
-            # As a compromise we check for the base name of the module so we find
-            # "Java/whatever-11" when searching for "Java/11" (--> basename="Java")
-            basename = os.path.dirname(mod_name)
-            if basename:
-                names_to_check.append(basename)
-            for name in names_to_check:
-                mod_exists_regex = mod_exists_regex_template % re.escape(name)
-                if re.search(mod_exists_regex, txt, re.M):
-                    res = True
-                    break
-            return res
+            return bool(re.search(mod_exists_regex, txt, re.M))
 
         if skip_avail:
             avail_mod_names = []

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -755,8 +755,8 @@ class ModulesTool(object):
         # also catch and check exit code
         exit_code = proc.returncode
         if kwargs.get('check_exit_code', True) and exit_code != 0:
-            raise EasyBuildError("Module command 'module %s' failed with exit code %s; stderr: %s; stdout: %s",
-                                 ' '.join(cmd_list[2:]), exit_code, stderr, stdout)
+            raise EasyBuildError("Module command '%s' failed with exit code %s; stderr: %s; stdout: %s",
+                                 ' '.join(cmd_list), exit_code, stderr, stdout)
 
         if kwargs.get('check_output', True):
             self.check_module_output(full_cmd, stdout, stderr)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -273,10 +273,15 @@ class ModulesTest(EnhancedTestCase):
         self.assertTrue('Java/1.8.0_181' in avail_mods)
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
             self.assertTrue('Java/1.8' in avail_mods)
+            self.assertTrue('Java/site_default' in avail_mods)
+
         self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
-        # Check for an alias with a different version suffix than the base module
+
+        # check for an alias with a different version suffix than the base module
         self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
+
         self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
+        self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
 
         reset_module_caches()
 
@@ -289,6 +294,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
         self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
+        self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
@@ -306,9 +312,12 @@ class ModulesTest(EnhancedTestCase):
             self.assertTrue('Java/1.8.0_181' in avail_mods)
             self.assertTrue('Java/1.8' in avail_mods)
             self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
-            # Check for an alias with a different version suffix than the base module
+
+            # check for an alias with a different version suffix than the base module
             self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
+
             self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
+            self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
 
             reset_module_caches()
 
@@ -319,6 +328,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
             self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
+            self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
 
     def test_load(self):
         """ test if we load one module it is in the loaded_modules """

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -147,9 +147,9 @@ class ModulesTest(EnhancedTestCase):
         res = self.modtool.run_module('list')
         self.assertEqual(res, [{'mod_name': 'GCC/6.4.0-2.28', 'default': None}])
 
-        res = self.modtool.run_module('avail', 'GCC/4.6')
+        res = self.modtool.run_module('avail', 'GCC/4.6.3')
         self.assertTrue(isinstance(res, list))
-        self.assertEqual(sorted([x['mod_name'] for x in res]), ['GCC/4.6.3', 'GCC/4.6.4'])
+        self.assertEqual(sorted([x['mod_name'] for x in res]), ['GCC/4.6.3'])
 
         # loading a module produces no output, so we get an empty list
         res = self.modtool.run_module('load', 'OpenMPI/2.1.2-GCC-6.4.0-2.28')

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -113,17 +113,34 @@ class ModulesTest(EnhancedTestCase):
         self.modtool.run_module(['load', 'GCC/6.4.0-2.28'])
         self.assertEqual(os.environ['EBROOTGCC'], '/prefix/software/GCC/6.4.0-2.28')
 
-        # by default, exit code is checked and an error is raised if we run something that fails
-        error_pattern = "Module command 'module thisdoesnotmakesense' failed with exit code [1-9]"
-        self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.run_module, 'thisdoesnotmakesense')
+        # skip tests that rely on exit codes when using EnvironmentModulesTcl modules tool,
+        # because it doesn't use proper exit codes
+        if not isinstance(self.modtool, EnvironmentModulesTcl):
 
-        error_pattern = "Module command 'module load nosuchmodule/1.2.3' failed with exit code [1-9]"
-        self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.run_module, 'load', 'nosuchmodule/1.2.3')
+            # by default, exit code is checked and an error is raised if we run something that fails
+            error_pattern = "Module command '.*thisdoesnotmakesense' failed with exit code [1-9]"
+            self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.run_module, 'thisdoesnotmakesense')
+
+            # we need to use a different error pattern here with EnvironmentModulesC,
+            # because a load of a non-existing module doesnt' trigger a non-zero exit code...
+            # it will still fail though, just differently
+            if isinstance(self.modtool, EnvironmentModulesC):
+                error_pattern = "Unable to locate a modulefile for 'nosuchmodule/1.2.3'"
+            else:
+                error_pattern = "Module command '.*load nosuchmodule/1.2.3' failed with exit code [1-9]"
+            self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.run_module, 'load', 'nosuchmodule/1.2.3')
 
         # we can choose to blatently ignore the exit code,
-        # and also disable the output check that serves as a fallback
-        self.modtool.run_module('thisdoesnotmakesense', check_exit_code=False, check_output=False)
-        self.modtool.run_module('load', 'nosuchmodule/1.2.3', check_exit_code=False, check_output=False)
+        # and also disable the output check that serves as a fallback;
+        # we also enable return_output here, because trying to apply the environment changes produced
+        # by a faulty command is bound to cause trouble...
+        kwargs = {
+            'check_exit_code': False,
+            'check_output': False,
+            'return_output': True,
+        }
+        self.modtool.run_module('thisdoesnotmakesense', **kwargs)
+        self.modtool.run_module('load', 'nosuchmodule/1.2.3', **kwargs)
 
         # by default, the output (stdout+stderr) produced by the command is processed;
         # result is a list of useful info (module names in case of list/avail)
@@ -1184,7 +1201,7 @@ class ModulesTest(EnhancedTestCase):
     def test_exit_code_check(self):
         """Verify that EasyBuild checks exit code of executed module commands"""
         if isinstance(self.modtool, Lmod):
-            error_pattern = "Module command 'module load nosuchmoduleavailableanywhere' failed with exit code"
+            error_pattern = "Module command '.*load nosuchmoduleavailableanywhere' failed with exit code"
         else:
             # Tcl implementations exit with 0 even when a non-existing module is loaded...
             error_pattern = "Unable to locate a modulefile for 'nosuchmoduleavailableanywhere'"

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1336,7 +1336,7 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_ec, ectxt + extraectxt)
 
         if isinstance(self.modtool, Lmod):
-            err_msg = r"Module command \\'module load nosuchbuilddep/0.0.0\\' failed"
+            err_msg = r"Module command \\'.*load nosuchbuilddep/0.0.0\\' failed"
         else:
             err_msg = r"Unable to locate a modulefile for 'nosuchbuilddep/0.0.0'"
 
@@ -1348,7 +1348,7 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_ec, ectxt + extraectxt)
 
         if isinstance(self.modtool, Lmod):
-            err_msg = r"Module command \\'module load nosuchmodule/1.2.3\\' failed"
+            err_msg = r"Module command \\'.*load nosuchmodule/1.2.3\\' failed"
         else:
             err_msg = r"Unable to locate a modulefile for 'nosuchmodule/1.2.3'"
 


### PR DESCRIPTION
@Flamefire changes for https://github.com/easybuilders/easybuild-framework/pull/3216

The changes you made to `mod_exists_via_show` are not needed, thanks to the fallback to `module_wrapper_exists` in `ModulesTool.show` (cfr. https://github.com/easybuilders/easybuild-framework/pull/2606), so I rolled them back.

The additional checks you (and I) added to `test_exist` still pass when those changes are undone.

As you explained in #3215 there may be use cases that do warrant changes to `mod_exists_via_show` (for example aliases defined via `module_alias`), but they are currently not covered by the tests.
That should be tackled first, before changes are made to fix those issues.
In the context of `module_alias`, I'm not sure the changes you proposed to `mod_exists_via_show` would cut it though...

The bulk of these changes in this PR are additional tests beyond the scope of your PR. I noticed that we didn't have any tests yet for `ModulesTool.run_module` or `ModulesTool.show`, so I spent some time on fixing that.
If needed I can flesh out those additional tests in a separate PR (but since a small part of them, the `return_stderr` part) relies on changes in your PR, I included them here.